### PR TITLE
Build for Arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ local-%: ## Builds the specified target defined in the Dockerfile using the loca
 	@$(MAKE) target-$* TARGET_ARGS="--output=type=local,dest=$(DEST) $(TARGET_ARGS)"
 
 docker-%: ## Builds the specified target defined in the Dockerfile using the docker output type. The build result will be loaded into docker.
-	@$(MAKE) target-$* TARGET_ARGS="--tag $(IMAGE):$(TAG) $(TARGET_ARGS)"
+	@$(MAKE) target-$* TARGET_ARGS="--output=type=docker --tag $(IMAGE):$(TAG) $(TARGET_ARGS)"
 
 # Code Generation
 


### PR DESCRIPTION
- updated and used arm image for:
    protoc
    kustomize
- Fixed docker-% step
- wip: hardcoded arm64 architecture for go

Tip: The project generates three docker images. There were built with something like `make docker-cluster-api-provider-sidero REGISTRY=docker.io USERNAME=galadrielio TAG=v0.1.0-alpha.12-27-g9c72b80-dirty-arm64 TOOLS=ghcr.io/talos-systems/tools:v0.5.0-alpha.0-1-gbcf3380 PKGS=v0.4.1-2-gd471b60 PUSH=false NAME=cluster-api-provider-sidero`.

Discussion: Notice that I had to guess the version of PKGS as the "least common denominator" of the images that are available for each of the `FROM` images inside the Dockerfile. I think this could be done automatically.
Also, for some reason `NAME` needs to be passed when it would be easily guessed from the make target.
